### PR TITLE
Update for 1.16.4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Disable autocrlf on generated files, they always generate with LF
+# Add any extra files or paths here to make git stop saying they
+# are changed when only line endings change.
+src/generated/**/.cache/cache text eol=lf
+src/generated/**/*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+logs
+
+# other
+eclipse
+run
+build.bat
+setup*.bat

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.1-0.2.2'
+version = '1.16.4-0.1.0'
 group = 'com.nottoomanyitems.stepup' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'StepUp'
 
@@ -25,7 +25,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20200514-1.16'
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -89,7 +89,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.1-32.0.24'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/com/nottoomanyitems/stepup/StepUp.java
+++ b/src/main/java/com/nottoomanyitems/stepup/StepUp.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 public final class StepUp {
     public static final String MODID = "stepup";
   
-	public static final String MOD_VERSION = "1.16.1-0.2.0";
+	public static final String MOD_VERSION = "1.16.4-0.1.0";
 	public static final String MOD_NAME = "StepUp";
 	public static String MC_VERSION;
 	

--- a/src/main/java/com/nottoomanyitems/stepup/config/ConfigIO.java
+++ b/src/main/java/com/nottoomanyitems/stepup/config/ConfigIO.java
@@ -169,6 +169,6 @@ public class ConfigIO{
     }
     
     public static void debugMessage(String m) {
-    	StepChanger.player.sendMessage((ITextComponent) new StringTextComponent(m), Util.field_240973_b_);
+    	StepChanger.player.sendMessage((ITextComponent) new StringTextComponent(m), Util.DUMMY_UUID);
     }
 }

--- a/src/main/java/com/nottoomanyitems/stepup/worker/StepChanger.java
+++ b/src/main/java/com/nottoomanyitems/stepup/worker/StepChanger.java
@@ -106,20 +106,20 @@ public class StepChanger {
             m = m + (Object) TextFormatting.GREEN + I18n.format(AutoJumpState.MINECRAFT.getDesc());
         }
 
-        player.sendMessage((ITextComponent) new StringTextComponent(m), Util.field_240973_b_);
+        player.sendMessage((ITextComponent) new StringTextComponent(m), Util.DUMMY_UUID);
     }
     
     private static void updateMessage() {
         String m2 = (Object) TextFormatting.GOLD + I18n.format("msg.stepup.updateAvailable") + ": " + (Object) TextFormatting.DARK_AQUA + "[" + (Object) TextFormatting.YELLOW + "StepUp-" + (Object) TextFormatting.WHITE + VersionChecker.getLatestVersion() + (Object) TextFormatting.DARK_AQUA + "]";
         String url = "https://www.curseforge.com/minecraft/mc-mods/stepup/files";
         ClickEvent versionCheckChatClickEvent = new ClickEvent(ClickEvent.Action.OPEN_URL, url);
-        HoverEvent versionCheckChatHoverEvent = new HoverEvent(HoverEvent.Action.field_230550_a_, new StringTextComponent(I18n.format("msg.stepup.updateTooltip") + "!"));
+        HoverEvent versionCheckChatHoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new StringTextComponent(I18n.format("msg.stepup.updateTooltip") + "!"));
         TextComponent component = new StringTextComponent(m2);
         Style s = component.getStyle();
-        s.func_240715_a_(versionCheckChatClickEvent);	//setClickEvent
-        s.func_240716_a_(versionCheckChatHoverEvent);	//setHoverEvent
-        component.func_230530_a_(s);
-        player.sendMessage((ITextComponent) component, Util.field_240973_b_);
+        s.setClickEvent(versionCheckChatClickEvent);	//setClickEvent
+        s.setHoverEvent(versionCheckChatHoverEvent);	//setHoverEvent
+        component.setStyle(s);
+        player.sendMessage((ITextComponent) component, Util.DUMMY_UUID);
     }
     
     public enum AutoJumpState

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,53 +1,32 @@
-# This is an example mods.toml file. It contains the data relating to the loading mods.
-# There are several mandatory fields (#mandatory), and many more that are optional (#optional).
-# The overall format is standard TOML format, v0.5.0.
-# Note that there are a couple of TOML lists in this file.
-# Find more information on toml format here:  https://github.com/toml-lang/toml
-# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
-modLoader="javafml" #mandatory
-# A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[32,)" #mandatory (32 is current forge version)
-# A URL to refer people to when problems occur with this mod
-#issueTrackerURL="http://my.issue.tracker/" #optional
-# A list of mods - how many allowed here is determined by the individual mod loader
-[[mods]] #mandatory
-# The modid of the mod
-modId="stepup" #mandatory
-# The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
-version="${version}" #mandatory
+modLoader="javafml"
+loaderVersion="[35,)"
+#issueTrackerURL="http://my.issue.tracker/"
+license="All rights reversed"
+
+[[mods]]
+modId="stepup"
+version="${version}"
 state="Working"
- # A display name for the mod
-displayName="StepUp" #mandatory
-# A URL to query for updates for this mod. See the JSON update specification <here>
-#updateJSONURL="http://myurl.me/" #optional
-# A URL for the "homepage" for this mod, displayed in the mod UI
-displayURL="https://www.curseforge.com/minecraft/mc-mods/stepup" #optional
-# A file name (in the root of the mod JAR) containing a logo for display
-logoFile="logo.png" #optional
-# A text field displayed in the mod UI
-credits="NotTooManyItems, frakier" #optional
-# A text field displayed in the mod UI
-authors="NotTooManyItems" #optional
-# The description text for the mod (multi line!) (#mandatory)
+displayName="StepUp"
+#updateJSONURL="http://myurl.me/"
+displayURL="https://www.curseforge.com/minecraft/mc-mods/stepup"
+logoFile="logo.png"
+credits="NotTooManyItems, frakier"
+authors="NotTooManyItems"
 description='''
 3 options allow you to choose between no auto jump, Minecraft auto jump, and StepUp auto jump
 '''
-# A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.stepup]] #optional
-    # the modid of the dependency
-    modId="forge" #mandatory
-    # Does this dependency have to exist - if not, ordering below must be specified
-    mandatory=true #mandatory
-    # The version range of the dependency
-    versionRange="[32,)" #mandatory
-    # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
-    ordering="NONE"
-    # Side this dependency is applied on - BOTH, CLIENT or SERVER
-    side="BOTH"
-# Here's another dependency
+
 [[dependencies.stepup]]
-    modId="minecraft"
-    mandatory=true
-    versionRange="[1.16.1]"
-    ordering="NONE"
-    side="CLIENT"
+modId="forge"
+mandatory=true
+versionRange="[35,)"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.stepup]]
+modId="minecraft"
+mandatory=true
+versionRange="[1.16.4,1.17)"
+ordering="NONE"
+side="CLIENT"


### PR DESCRIPTION
1. updated version to 1.16.4.
2. updated forge mappings and fixed referenced fields and methods.
3. added license to and removed comments from mods.toml.

Fixes the current load issue with running under 1.16.4 and 1.16.5.