### PR TITLE
StepUp Info Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# eclipse
+bin
+eclipse
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+logs
+
+# other
+run

--- a/src/main/java/com/nottoomanyitems/stepup/StepUp.java
+++ b/src/main/java/com/nottoomanyitems/stepup/StepUp.java
@@ -1,6 +1,8 @@
 package com.nottoomanyitems.stepup;
 
+import com.nottoomanyitems.stepup.config.Configuration;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 
 import com.nottoomanyitems.stepup.Client.ClientProxy;
@@ -19,11 +21,11 @@ public final class StepUp {
   
 	public static final String MOD_VERSION = "1.16.4-0.2.0";
 	public static final String MOD_NAME = "StepUp";
-	public static String MC_VERSION;
 	
 	public static final StepUpProxy proxy = DistExecutor.safeRunForDist(() -> ClientProxy::new, () -> ServerProxy::new);
 	
 	public StepUp() {
+		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Configuration.CLIENT_SPEC);
     }
 	
 	@SubscribeEvent

--- a/src/main/java/com/nottoomanyitems/stepup/config/Configuration.java
+++ b/src/main/java/com/nottoomanyitems/stepup/config/Configuration.java
@@ -1,0 +1,31 @@
+package com.nottoomanyitems.stepup.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class Configuration {
+
+    public static final ForgeConfigSpec CLIENT_SPEC;
+    public static final Client CLIENT;
+
+    static {
+        Pair<Client,ForgeConfigSpec> clientSpecPair = new ForgeConfigSpec.Builder().configure(Client::new);
+
+        CLIENT_SPEC = clientSpecPair.getRight();
+        CLIENT = clientSpecPair.getLeft();
+    }
+
+    public static class Client {
+
+        public BooleanValue showStepUpInfoOnWorldJoin;
+
+        Client(ForgeConfigSpec.Builder builder)
+        {
+            showStepUpInfoOnWorldJoin = builder
+                    .comment("Whether info about StepUp will be show when joining a world.")
+                    .translation("config.stepup.showStepUpInfoOnWorldJoin")
+                    .define("showStepUpInfoOnWorldJoin", true);
+        }
+    }
+}

--- a/src/main/java/com/nottoomanyitems/stepup/worker/StepChanger.java
+++ b/src/main/java/com/nottoomanyitems/stepup/worker/StepChanger.java
@@ -2,6 +2,7 @@ package com.nottoomanyitems.stepup.worker;
 
 import com.nottoomanyitems.stepup.StepUp;
 import com.nottoomanyitems.stepup.config.ConfigIO;
+import com.nottoomanyitems.stepup.config.Configuration;
 import com.nottoomanyitems.stepup.config.VersionChecker;
 import com.nottoomanyitems.stepup.init.KeyBindings;
 
@@ -42,7 +43,6 @@ public class StepChanger {
         } else if (autoJumpState == 0 && player.stepHeight >= 1.0f && forceStepUp == true) { //All Disabled
         	player.stepHeight = .6f;
         	forceStepUp = false;
-        	//player.sendMessage((ITextComponent) new StringTextComponent("ASDJKJKJSD"), Util.field_240973_b_);
         } else if (autoJumpState == 1 && player.stepHeight < 1.0f) { //StepUp Enabled
             player.stepHeight = 1.25f;
             forceStepUp = true;
@@ -55,21 +55,23 @@ public class StepChanger {
 
     public static void init() {
     	if(firstRun) {
-            if (VersionChecker.isLatestVersion() == false) {
+            if (Configuration.CLIENT.showStepUpInfoOnWorldJoin.get() && VersionChecker.isLatestVersion() == false) {
                 updateMessage();
             }
             firstRun = false;
     	}
     	ConfigIO.CheckForServerIP();
     	autoJump();
-        message();
+        if (Configuration.CLIENT.showStepUpInfoOnWorldJoin.get()) {
+            message();
+        }
     }
     
     //@SubscribeEvent
     public static void onKeyInput(KeyInputEvent event) {
     	int autoJumpState = ConfigIO.autoJumpState;
 
-        if (KeyBindings.KEYBINDINGS[0].isPressed()) {	//(event.getKey() == 36) HOME KEY
+        if (KeyBindings.KEYBINDINGS[0].isPressed()) {
             if (autoJumpState == AutoJumpState.MINECRAFT.getLevelCode()) {
             	ConfigIO.autoJumpState = AutoJumpState.DISABLED.getLevelCode(); //0 StepUp and Minecraft Disabled
             } else if (autoJumpState == AutoJumpState.DISABLED.getLevelCode()) {

--- a/src/main/resources/assets/stepup/lang/en_us.json
+++ b/src/main/resources/assets/stepup/lang/en_us.json
@@ -6,5 +6,7 @@
     "msg.stepup.minecraft": "Minecraft AutoJump Enabled",
     "msg.stepup.updateAvailable": "A new version of StepUp is available",
     "msg.stepup.updateTooltip": "Click here to update from CurseForge",
-    "msg.stepup.config.desc": "The Current State of StepUp\r 0 All Disabled,\r 1 StepUp Enabled,\r 2 Minecraft Jump Enabled"
+    "msg.stepup.config.desc": "The Current State of StepUp\r 0 All Disabled,\r 1 StepUp Enabled,\r 2 Minecraft Jump Enabled",
+    "config.stepup.showStepUpInfoOnWorldJoin": "Show StepUp information when joining world.",
+    "config.stepup.showStepUpInfoOnWorldJoin.tooltip": "Whether info about StepUp will be show when joining a world."
 }


### PR DESCRIPTION
Added a configuration option to enable/disable the StepUp information messages when joining a world.
NOTE: This does not disable StepUp status change messages when pressing the associated key.

This should address the two open issues #5 and #11.
